### PR TITLE
Use an internal logger instance to print request and response logs

### DIFF
--- a/sdklib/http/sdk_base.py
+++ b/sdklib/http/sdk_base.py
@@ -164,7 +164,6 @@ class HttpSdk(object):
         self.default_renderer = default_renderer or self.DEFAULT_RENDERER
         self._cookie = None
         self.incognito_mode = False
-        self.logger = logging.getLogger(__name__)
 
     @property
     def host(self):
@@ -269,12 +268,11 @@ class HttpSdk(object):
             cls.DEFAULT_PROXY = "%s://%s:%s" % (scheme, host, port)
 
     @staticmethod
-    def http_request_from_context(context, logger=None, **kwargs):
+    def http_request_from_context(context, **kwargs):
         """
         Method to do http requests from context.
 
         :param context: request context.
-        :param logger: Logger instance to be used to print the request and response data.
         """
         context.method = context.method.upper()
         assert context.method in ALLOWED_METHODS
@@ -297,10 +295,10 @@ class HttpSdk(object):
         if context.query_params is not None:
             url += "?%s" % (urlencode(context.query_params))
 
-        log_print_request(logger, context.method, url, context.query_params, context.headers, body)
+        log_print_request(context.method, url, context.query_params, context.headers, body)
         r = HttpSdk.get_pool_manager(context.proxy).request(context.method, url, body=body, headers=context.headers,
                                                             redirect=False)
-        log_print_response(logger, r.status, r.data, r.headers)
+        log_print_response(r.status, r.data, r.headers)
         r = context.response_class(r)
         return r
 
@@ -349,7 +347,7 @@ class HttpSdk(object):
             authentication_instances=authentication_instances,
             update_content_type=update_content_type
         )
-        res = self.http_request_from_context(context, self.logger)
+        res = self.http_request_from_context(context)
         self.cookie = res.cookie
         return res
 

--- a/sdklib/util/logger.py
+++ b/sdklib/util/logger.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import json
+import logging
 from xml.dom.minidom import parseString
 
 from sdklib.http.headers import CONTENT_TYPE_HEADER_NAME
 from sdklib.http.renderers import JSONRenderer, XMLRenderer
+
+logger = logging.getLogger(__name__)
 
 
 def _get_pretty_body(headers, body):
@@ -30,10 +33,9 @@ def _get_pretty_body(headers, body):
         return body
 
 
-def log_print_request(logger, method, url, query_params=None, headers=None, body=None):
+def log_print_request(method, url, query_params=None, headers=None, body=None):
     """
     Log an HTTP request data in a user-friendly representation.
-    :param logger: Logger to use
     :param method: HTTP method
     :param url: URL
     :param query_params: Query parameters in the URL
@@ -42,37 +44,34 @@ def log_print_request(logger, method, url, query_params=None, headers=None, body
     :return: None
     """
 
-    if logger:
-        log_msg = '\n>>>>>>>>>>>>>>>>>>>>> Request >>>>>>>>>>>>>>>>>>> \n'
-        log_msg += '\t> Method: %s\n' % method
-        log_msg += '\t> Url: %s\n' % url
-        if query_params is not None:
-            log_msg += '\t> Query params: {}\n'.format(str(query_params))
-        if headers is not None:
-            log_msg += '\t> Headers:\n{}\n'.format(json.dumps(dict(headers), sort_keys=True, indent=4))
-        if body is not None:
-            log_msg += '\t> Payload sent:\n{}\n'.format(_get_pretty_body(headers, body))
+    log_msg = '\n>>>>>>>>>>>>>>>>>>>>> Request >>>>>>>>>>>>>>>>>>> \n'
+    log_msg += '\t> Method: %s\n' % method
+    log_msg += '\t> Url: %s\n' % url
+    if query_params is not None:
+        log_msg += '\t> Query params: {}\n'.format(str(query_params))
+    if headers is not None:
+        log_msg += '\t> Headers:\n{}\n'.format(json.dumps(dict(headers), sort_keys=True, indent=4))
+    if body is not None:
+        log_msg += '\t> Payload sent:\n{}\n'.format(_get_pretty_body(headers, body))
 
-        logger.debug(log_msg)
+    logger.debug(log_msg)
 
 
-def log_print_response(logger, status_code, response, headers=None):
+def log_print_response(status_code, response, headers=None):
     """
     Log an HTTP response data in a user-friendly representation.
-    :param logger: __logger__ to use
     :param status_code: HTTP Status Code
     :param response: Raw response content (string)
     :param headers: Headers in the response (dict)
     :return: None
     """
 
-    if logger:
-        log_msg = '\n<<<<<<<<<<<<<<<<<<<<<< Response <<<<<<<<<<<<<<<<<<\n'
-        log_msg += '\t< Response code: {}\n'.format(str(status_code))
-        if headers is not None:
-            log_msg += '\t< Headers:\n{}\n'.format(json.dumps(dict(headers), sort_keys=True, indent=4))
-        try:
-            log_msg += '\t< Payload received:\n{}'.format(_get_pretty_body(headers, response))
-        except:
-            log_msg += '\t< Payload received:\n{}'.format(response)
-        logger.debug(log_msg)
+    log_msg = '\n<<<<<<<<<<<<<<<<<<<<<< Response <<<<<<<<<<<<<<<<<<\n'
+    log_msg += '\t< Response code: {}\n'.format(str(status_code))
+    if headers is not None:
+        log_msg += '\t< Headers:\n{}\n'.format(json.dumps(dict(headers), sort_keys=True, indent=4))
+    try:
+        log_msg += '\t< Payload received:\n{}'.format(_get_pretty_body(headers, response))
+    except:
+        log_msg += '\t< Payload received:\n{}'.format(response)
+    logger.debug(log_msg)


### PR DESCRIPTION
It's not necessary to pass a logger instance to *http_request_from_context()* method.
A new logger instance can be created in *utils/logger.py* instead of using an external logger.