### PR TITLE
fix: multipart boundary does not meet the RFC

### DIFF
--- a/sdklib/http/renderers.py
+++ b/sdklib/http/renderers.py
@@ -79,7 +79,7 @@ def guess_file_name_stream_type_header(args):
 
 class MultiPartRenderer(BaseRenderer):
 
-    def __init__(self, boundary="----------ThIs_Is_tHe_bouNdaRY_$", output_str='javascript'):
+    def __init__(self, boundary="----------ThIs_Is_tHe_bouNdaRY", output_str='javascript'):
         self.boundary = boundary
         self.output_str = output_str
 


### PR DESCRIPTION
https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
````
boundary := 0*69<bchars> bcharsnospace 

bchars := bcharsnospace / " " 

bcharsnospace :=    DIGIT / ALPHA / "'" / "(" / ")" / "+"  / 
"_" 
               / "," / "-" / "." / "/" / ":" / "=" / "?"
````